### PR TITLE
Bugfix/multiple dyn params impossible fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.4.4",
         "ext-soap": "*",
-        "craklabs/soap-client": "dev-master"
+        "craklabs/soap-client": "v0.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mylittleparis/campaign-commander",
+    "name": "craklabs/campaign-commander",
     "type": "library",
     "license": "BSD-3-Clause",
     "description": "Client for the Campaign Commander API (wrapper)",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mylittleparis/campaign-commander",
+    "name": "coolfarmer/campaign-commander",
     "type": "library",
     "license": "BSD-3-Clause",
     "description": "Client for the Campaign Commander API (wrapper)",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.4.4",
         "ext-soap": "*",
-        "besimple/soap-client": "0.2.*"
+        "craklabs/soap-client": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "coolfarmer/campaign-commander",
+    "name": "craklabs/campaign-commander",
     "type": "library",
     "license": "BSD-3-Clause",
     "description": "Client for the Campaign Commander API (wrapper)",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.4.4",
         "ext-soap": "*",
-        "craklabs/soap-client": "v0.2.*"
+        "craklabs/soap-client": "0.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.4.4",
         "ext-soap": "*",
-        "craklabs/soap-client": "0.2.7"
+        "craklabs/soap-client": "~0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.4.4",
         "ext-soap": "*",
-        "craklabs/soap-client": "0.2.*"
+        "craklabs/soap-client": "0.2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/src/API/SOAP/APIClient.php
+++ b/src/API/SOAP/APIClient.php
@@ -109,7 +109,10 @@ class APIClient implements ClientInterface
     public function __destruct()
     {
         try {
-            $this->soapClient->__soapCall('closeApiConnection', [['token' => $this->token]]);
+            // close connection if needed
+            if (!empty($this->login)) {
+                $this->soapClient->__soapCall('closeApiConnection', [['token' => $this->token]]);
+            }
 
             $this->soapClient = null;
             $this->token = null;
@@ -141,7 +144,7 @@ class APIClient implements ClientInterface
     public function doCall($method, array $parameters = [])
     {
         // open connection if needed
-        if ($this->soapClient === null || $this->token === null) {
+        if ($this->soapClient === null || $this->token === null || !empty($this->login)) {
             $this->openApiConnection();
         }
 

--- a/src/API/SOAP/APIClient.php
+++ b/src/API/SOAP/APIClient.php
@@ -110,7 +110,7 @@ class APIClient implements ClientInterface
     {
         try {
             // close connection if needed
-            if (!empty($this->login)) {
+            if ($this->login !== null) {
                 $this->soapClient->__soapCall('closeApiConnection', [['token' => $this->token]]);
             }
 
@@ -144,7 +144,7 @@ class APIClient implements ClientInterface
     public function doCall($method, array $parameters = [])
     {
         // open connection if needed
-        if ($this->soapClient === null || $this->token === null || !empty($this->login)) {
+        if (($this->soapClient === null || $this->token === null) && $this->login !== null) {
             $this->openApiConnection();
         }
 

--- a/src/API/SOAP/StandardClientFactory.php
+++ b/src/API/SOAP/StandardClientFactory.php
@@ -80,6 +80,7 @@ class StandardClientFactory implements ClientFactoryInterface
             ->withTrace()
             ->withExceptions()
             ->withWsdlCacheNone()
+            ->withMtomAttachments()
             ->withWsdl($this->server . '/' . $wsdl)
             ->build()
         ;

--- a/src/API/SOAP/StandardNoAuthClientFactory.php
+++ b/src/API/SOAP/StandardNoAuthClientFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MyLittle\CampaignCommander\API\SOAP;
+
+use MyLittle\CampaignCommander\API\SOAP\ClientFactoryInterface;
+use BeSimple\SoapClient\SoapClientBuilder;
+
+/**
+ * Class StandardClientFactory
+ *
+ * @package  MyLittle\CampaignCommander\API\SOAP
+ * @author   Olivier Beauchemin <obeauchemin@crakmedia.com>
+ */
+class StandardNoAuthClientFactory implements ClientFactoryInterface
+{
+    /**
+     * @var SoapClientBuilder
+     */
+    protected $builder;
+
+    /**
+     * The server to use
+     *
+     * @var string
+     */
+    protected $server;
+
+    /**
+     * Constructor
+     *
+     * @param \BeSimple\SoapClient\SoapClientBuilder $builder
+     * @param string $server
+     */
+    public function __construct(SoapClientBuilder $builder, $server)
+    {
+        $this->builder = $builder;
+        $this->server = $server;
+    }
+
+    /**
+     * Create the client
+     *
+     * @param string $wsdl
+     *
+     * @return \MyLittle\CampaignCommander\API\SOAP\APIClient
+     */
+    public function createClient($wsdl)
+    {
+        $soapClient = $this->builder
+            ->withEncoding('UTF-8')
+            ->withSingleElementArrays()
+            ->withUserAgent('PHP/SOAP CampaignCommander')
+            ->withSoapVersion11()
+            ->withTrace()
+            ->withExceptions()
+            ->withWsdlCacheNone()
+            ->withWsdl($this->server . '/' . $wsdl)
+            ->build()
+        ;
+
+        return new APIClient(
+            $soapClient,
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/Service/BatchMemberService.php
+++ b/src/Service/BatchMemberService.php
@@ -38,7 +38,7 @@ class BatchMemberService
      * @param string $mapping
      * @param string $fileEncoding
      * @param string $separator
-     * @param boolean $skipFirsLine
+     * @param boolean $skipFirstLine
      * @param string $dateFormat
      *
      * @return string The ID of the upload job
@@ -50,19 +50,19 @@ class BatchMemberService
         $mapping,
         $fileEncoding = 'UTF-8',
         $separator = '|',
-        $skipFirsLine = false,
+        $skipFirstLine = false,
         $dateFormat = 'mm/dd/yyyy'
     ) {
-        $parameters['mergeUpload'] = [
+        $parameters['file'] = $fileContent;
+        $parameters['mergeUpload'] = array(
             'fileName' => (string) $filename,
             'fileEncoding' => (string) $fileEncoding,
             'separator' => (string) $separator,
-            'skipFirstLine' => $skipFirsLine,
+            'skipFirstLine' => $skipFirstLine,
             'dateFormat' => (string) $dateFormat,
             'criteria' => (string) $criteria,
             'mapping' => $mapping,
-            'file' => $fileContent,
-        ];
+        );
 
         return (string) $this->apiClient->doCall('uploadFileMerge', $parameters);
     }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -84,7 +84,7 @@ class NotificationService
                 $parameters['arg0']['dyn'] = [
                     'entry' => [
                         'key' => $key,
-                        'value' => "<![CDATA[$value]]",
+                        'value' => $value,
                     ]
                 ];
             }
@@ -97,7 +97,7 @@ class NotificationService
                 $parameters['arg0']['content'] = [
                     'entry' => [
                         'key' => $key,
-                        'value' => "<![CDATA[$value]]",
+                        'value' => $value,
                     ]
                 ];
             }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -80,29 +80,43 @@ class NotificationService
         // Dynamic Personalization Parameters
         $parameters['arg0']['dyn'] = array();
         if (null !== $dyn) {
+
+            $contentEntry = array();
+
             foreach ($dyn as $key => $value) {
-                $parameters['arg0']['dyn'] = [
-                    'entry' => [
-                        'key' => $key,
-                        'value' => $value,
-                    ]
+                $contentEntry[] = [
+                    'key' => $key,
+                    'value' => $value,
                 ];
             }
+
+            $parameters['arg0']['dyn'] = [
+                'entry' => $contentEntry
+            ];
+
         }
 
         // Content Parameters
         $parameters['arg0']['content'] = array();
         if (null !== $content) {
+
+            $contentEntry = array();
+
             foreach ($content as $key => $value) {
-                $parameters['arg0']['content'] = [
-                    'entry' => [
-                        'key' => $key,
-                        'value' => $value,
-                    ]
+                $contentEntry[] = [
+                    'key' => $key,
+                    'value' => $value,
                 ];
             }
-        }
 
+            if(!empty($contentEntry)) {
+                $parameters['arg0']['content'] = [
+                    'entry' => $contentEntry
+                ];
+            }
+
+        }
+        //print_r($parameters['arg0']['content']);die;
         return (string) $this->apiClient->doCall('sendObject', $parameters);
     }
 }


### PR DESCRIPTION
Il était impossible de mettre plusieurs paramètres dynamique, car le seconds écrasait le premier, le troisième écrasait le précédent et ainsi de suite.
